### PR TITLE
Added Token Feature

### DIFF
--- a/cli_app/cli.cpp
+++ b/cli_app/cli.cpp
@@ -8,11 +8,14 @@ const std::string TOOL_NAME = "EnglishFormatter";
 const std::string TOOL_VERSION = "0.1";
 std::string model = "llama3-8b-8192";
 std::string output_name = "_modified";
+bool showTokenUsage = false;
 
 int main( int argc, char *argv[]) {
 
     bool showVersion = false;
     bool showHelp = false;
+    dotenv::init();
+
 
     for (int i = 1; i < argc; ++i) {
         std::string arg = argv[i];
@@ -24,6 +27,8 @@ int main( int argc, char *argv[]) {
         else if (arg == "--help" || arg == "-h") {
             showHelp = true;
             break; // Exit the loop; no need to process further arguments
+        } else if (arg == "--token-usage" || arg == "-t") {
+            showTokenUsage = true;  // Set the token usage flag to true if this option is passed
         }
         else if (arg == "--model" || arg == "-m") {
             if (i + 1 < argc) {
@@ -65,12 +70,40 @@ int main( int argc, char *argv[]) {
             << "  -m, --model MODEL    Specify the model to use\n"
             << "  -o, --output NAME    Specify the output file suffix\n"
             << std::endl;
+        return 0;
 
     }
 
-    dotenv::init();
+    if (showTokenUsage) {
+        eng_format eng;
 
-    
+        try {
+            std::string response = eng.make_api_call("Sample prompt to LLM");
+
+
+            // Assuming the token info is parsed correctly from the response
+            std::string token_info = eng.get_token_info(response);
+
+            std::cerr << token_info << std::endl;  // Output to stderr as required
+        }
+        catch (const std::exception& e) {
+            std::cerr << "Error during API call: " << e.what() << std::endl;
+        }
+        return 0;
+    }
+
+
+
+
+
+    char* apiKeyCStr = std::getenv("API_KEY");
+    if (apiKeyCStr == nullptr) {
+        std::cerr << "Error: API_KEY is not set. Please set it in the .env file or as an environment variable." << std::endl;
+        return 1;
+    }
+    std::string apiKey = apiKeyCStr;
+    std::cout << "API_KEY obtained." << std::endl;
+
 
     // Define the menu items this should be done dynamically by someone who was administrator priviledges 
     // potential user input for more diversity

--- a/cli_app/display.cpp
+++ b/cli_app/display.cpp
@@ -42,6 +42,7 @@ void display::show_menu() {
             std::cout << "  " << menuItems[i] << std::endl;
         }
     }
+
 }
 
 

--- a/cli_app/eng_format.cpp
+++ b/cli_app/eng_format.cpp
@@ -118,3 +118,21 @@ void eng_format::convert_file(std::string filename, std::string Action) {
     filename += output_name;
     save_file(filename,parsed_data);
 }
+
+std::string eng_format::get_token_info(const std::string& response) {
+    // Parse the JSON response
+    auto json_response = json::parse(response);
+    if (json_response.contains("usage")) {
+        int prompt_tokens = json_response["usage"]["prompt_tokens"];
+        int completion_tokens = json_response["usage"]["completion_tokens"];
+        int total_tokens = json_response["usage"]["total_tokens"];
+
+        // Format the token usage information
+        return "Token usage:\nPrompt tokens: " + std::to_string(prompt_tokens) +
+            "\nCompletion tokens: " + std::to_string(completion_tokens) +
+            "\nTotal tokens: " + std::to_string(total_tokens);
+    }
+    else {
+        return "Token usage information not found in response.";
+    }
+}

--- a/cli_app/eng_format.hpp
+++ b/cli_app/eng_format.hpp
@@ -3,6 +3,7 @@
 // 09-Sep-24  F.Khan         Created.
 // 11-Sep-24  F.Khan         Added Curl
 // 14-Sep-24  F.Khan         Added nlohman json for parsing json objects
+// 19-Sep-24  I.Parmar       Added token Info feature 
 #ifndef _ENG_FORMAT_H_
 #define _ENG_FORMAT_H_
 #include "common.hpp"
@@ -35,6 +36,8 @@ public:
     std::string parse_response(const std::string& response);
     void save_file(const std::string& fileName, const std::string& content);
     void convert_file(std::string filename, std::string Action);
+    std::string get_token_info(const std::string& response);
+
 };
 
 #endif //_ENG_FORMAT_ H_


### PR DESCRIPTION
### Token Usage Feature
  Fixes #5 
This CLI tool now supports a new feature that allows users to track the number of tokens used when interacting with an LLM (Large Language Model) API. Tokens are a key metric for understanding API usage and staying within budget limits.
 
#### Usage
 
To display token usage information, use the `--token-usage` or `-t` flag when running the program. When this flag is passed, the program will output the number of tokens used in the prompt and completion phases.
 
**Example:**
 
```bash
./cli_app --token-usage
```
 
**Output:**
 
```
Token usage:
Prompt tokens: 57
Completion tokens: 17
Total tokens: 74
```
 
#### Explanation:
 
- **Prompt tokens**: The number of tokens used in the input prompt sent to the LLM.
- **Completion tokens**: The number of tokens used in the response generated by the LLM.
- **Total tokens**: The sum of both prompt and completion tokens.
 
This feature is helpful for debugging and tracking how many tokens are used in your API requests and responses.