### PR TITLE
Adding the test case

### DIFF
--- a/cli_app/tests/tests.cpp
+++ b/cli_app/tests/tests.cpp
@@ -46,6 +46,20 @@ TEST(EngFormatTests, HandlesResponseWithoutChoices) {
     std::string response = R"({"no_choices": [{"message": {"content": "Test"}}]})";
     EXPECT_THROW(formatter.parse_response(response), std::runtime_error);
 }
+TEST(EngFormatTests, SaveFileThrowsOnInvalidFile) {
+    // Set dummy environment variables for testing
+    setenv("API_KEY", "dummy_key", 1);
+    setenv("API_URL", "https://dummy.url", 1);
+
+    eng_format formatter;
+
+    // Use an invalid file path (e.g., a directory) to force an error
+    std::string invalidFilePath = "/invalid_path/test_output.txt";
+    std::string testContent = "This content should fail to save.";
+
+    // Ensure that the save_file method throws an exception for the invalid path
+    EXPECT_THROW(formatter.save_file(invalidFilePath, testContent), std::runtime_error);
+}
 
 // TEST(EngFormatTests, GetTokenInfoParsesCorrectly) {
 //     // Set dummy environment variables for testing


### PR DESCRIPTION
This test case verifies that the `save_file` method in the `eng_format` class correctly handles invalid file paths by throwing a `std::runtime_error` exception. The test sets dummy environment variables for testing purposes, initializes the `eng_format` object, and attempts to save content to an invalid file path (`/invalid_path/test_output.txt`). The expected behavior is that the method will throw an exception due to the invalid file path, ensuring robust error handling for file save operations.